### PR TITLE
add DEPRECATION notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# :warning: DEPRECATED REPO: DO NOT USE :warning:
+
 # az-kv-configured-aws
 
 Get a configured AWS library for a given role. Counts on entries in Azure Key Vault


### PR DESCRIPTION
closes #9  
> this is an anti-pattern that shouldn't be used. Key vault should only be fetched when the app is deployed not on every app restart.